### PR TITLE
Add Vercel deployment support with build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 /Ultraviolet-Static/node_modules
+dist/

--- a/api/bare.js
+++ b/api/bare.js
@@ -1,0 +1,11 @@
+import createBareServer from "@tomphttp/bare-server-node";
+
+const bare = createBareServer("/bare/");
+
+export default function handler(req, res) {
+  if (bare.shouldRoute(req)) {
+    bare.routeRequest(req, res);
+  } else {
+    res.status(400).json({ error: "Not a bare request" });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "node": ">=16.0.0"
   },
   "scripts": {
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "build": "node scripts/build.js"
   },
   "keywords": [
     "proxy"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,30 @@
+import { cpSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "..");
+const dist = join(root, "dist");
+
+// Clean previous build
+if (existsSync(dist)) {
+  rmSync(dist, { recursive: true });
+}
+mkdirSync(dist, { recursive: true });
+
+// 1. Copy UV library files to dist/uv/ (includes default uv.config.js)
+const uvSrc = join(
+  root,
+  "node_modules",
+  "@titaniumnetwork-dev",
+  "ultraviolet",
+  "dist"
+);
+mkdirSync(join(dist, "uv"), { recursive: true });
+cpSync(uvSrc, join(dist, "uv"), { recursive: true });
+
+// 2. Copy public static files to dist/ (custom uv.config.js overwrites the default)
+const publicDir = join(root, "Ultraviolet-Static", "public");
+cpSync(publicDir, dist, { recursive: true });
+
+console.log("Build complete: static files assembled in dist/");

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,26 @@
+{
+  "buildCommand": "npm run build",
+  "installCommand": "npm install",
+  "outputDirectory": "dist",
+  "cleanUrls": true,
+  "rewrites": [
+    { "source": "/bare", "destination": "/api/bare" },
+    { "source": "/bare/:path*", "destination": "/api/bare" }
+  ],
+  "headers": [
+    {
+      "source": "/uv/(.*)",
+      "headers": [
+        {
+          "key": "Service-Worker-Allowed",
+          "value": "/"
+        }
+      ]
+    }
+  ],
+  "functions": {
+    "api/bare.js": {
+      "maxDuration": 60
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds support for deploying the Ultraviolet proxy to Vercel by introducing a build script and Vercel configuration file. The changes enable static file assembly and serverless API routing for the bare server.

## Key Changes
- **Added `scripts/build.js`**: Build script that assembles static files by copying UV library files from node_modules and public static files to a `dist/` directory. The custom `uv.config.js` from the public directory overwrites the default configuration.
- **Added `vercel.json`**: Vercel configuration that specifies the build command, output directory, URL rewrites for the bare API, and Service-Worker-Allowed headers for UV files. Configures the bare API handler with a 60-second timeout.
- **Added `api/bare.js`**: Serverless function handler that routes bare server requests and returns a 400 error for non-bare requests.
- **Updated `package.json`**: Added `build` script that runs the build script.
- **Updated `.gitignore`**: Added `dist/` directory to ignore list.

## Implementation Details
- The build process cleans any previous build artifacts before creating the new `dist/` directory
- UV library files are copied first, then public files are overlaid to allow custom configuration overrides
- The Vercel configuration uses rewrites to route `/bare` requests to the serverless API handler
- Service-Worker-Allowed header is set for UV files to enable service worker registration at the root path

https://claude.ai/code/session_018YRdgoG4S62zzrhxSBa8bm